### PR TITLE
Add minimum functionality for init command

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,30 @@
+name: Go
+on: [push]
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-18.04
+    steps:
+
+    - name: Set up Go 1.13
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+
+    - name: Get dependencies
+      run: go get -v -t -d ./...
+
+    - name: Test
+      run: go test
+
+    - name: Build
+      run: go build -v .
+    
+    - name: Confirm output from built executable
+      run: ./clog
+  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# clog Change Log
+
+All notable changes associated with a release will be documented in this file.
+
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased] - YYYY-MM-DD
+
+### Major
+
+### Minor
+
+### Patch
+
+[Unreleased]: https://www.github.com/mjnt/clog/commits/master

--- a/README.md
+++ b/README.md
@@ -1,11 +1,41 @@
 # clog
 A CLI for standardizing change logs based on [semver][1].
 
-# Objectives
+## Commands
+
+### init [name]
+
+Create a new CHANGELOG.md file
+```
+clog init
+```
+
+Optionally takes a name argument. The containing folder name is used when the name is not specified.
+```
+clog init myProject
+```
+
+Example file contents:
+```
+# clog Change Log
+
+All notable changes associated with a release will be documented in this file.
+
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased] - YYYY-MM-DD
+
+### Major
+
+### Minor
+
+### Patch
+```
+## Objectives
 The goal is to port [this project][3] from nodejs to go.
 
 ## Format
-See format [here][2].
+See basis for format [here][2].
 
 [1]: https://semver.org/
 [2]: https://majgis.github.io/change-log/

--- a/main.go
+++ b/main.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+// Show CLI usage and exit with given exitCode
+func showUsageAndExit(exitCode int) {
+	fmt.Println("Usage:\n\ninit - create a new CHANGELOG.md file")
+	os.Exit(exitCode)
+}
+
+// Get project name from containing folder
+func getNameFromCWD() string {
+	cwd, cwdError := os.Getwd()
+	if cwdError != nil {
+		fmt.Println(cwdError)
+		os.Exit(1)
+	}
+
+	return filepath.Base(cwd)
+}
+
+// Get initial file contents given project name
+func getInitFileContents(name string) string {
+	fileTemplate := `# %s Change Log
+
+All notable changes associated with a release will be documented in this file.
+
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased] - YYYY-MM-DD
+
+### Major
+
+### Minor
+
+### Patch
+
+[Unreleased]: https://www.github.com/<org>/<project>/commits/master
+`
+	return fmt.Sprintf(fileTemplate, name)
+}
+
+// Write file contents to file path
+func writeToFile(fileContents, filePath string) error {
+	file, fileErr := os.Create("CHANGELOG.md")
+
+	if fileErr != nil {
+		return fileErr
+	}
+
+	_, writeErr := file.WriteString(fileContents)
+	file.Close()
+
+	return writeErr
+}
+
+func executeInit() error {
+	projectName := getNameFromCWD()
+	fileContents := getInitFileContents(projectName)
+	fileName := "CHANGELOG.md"
+	return writeToFile(fileContents, fileName)
+}
+
+// Execute a command by name
+func executeCommand(name string) error {
+	switch name {
+	case "init":
+		return executeInit()
+	default:
+		errorMessage := fmt.Sprintf("command: %s is not a valid command", name)
+		return errors.New(errorMessage)
+	}
+}
+
+// Entrypoint
+func main() {
+
+	// Parse command line arguments
+	flag.Parse()
+
+	// Print usage if no command was given
+	command := flag.Arg(0)
+	if command == "" {
+		showUsageAndExit(0)
+	}
+
+	// Execute command
+	commandErr := executeCommand(command)
+	if commandErr != nil {
+		log.Fatalln(commandErr)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,15 @@
+package main
+
+import "testing"
+
+// TestUnknownCommand verifies there is an error and it has expected value when a command is unknown
+func TestUnknownCommand(t *testing.T) {
+	commandErr := executeCommand("llamallamaredpajama")
+	if commandErr == nil {
+		t.Error("Expected error but got nil")
+	}
+	expectedErr := "command: llamallamaredpajama is not a valid command"
+	if commandErr.Error() != expectedErr {
+		t.Errorf("Expected error '%s' does not equal actual error '%s'", expectedErr, commandErr)
+	}
+}


### PR DESCRIPTION
This changeset includes the following:

* Single test
* Workflow to test, build and show usage
* Single command `init` added
    * In future PR: still need to correct url used in CHANGELOG.md
    * In future PR: still need to allow options unique to each command ( shout out if you have suggestion on library to use)
* Steps are broken out into separate functions
    * In future PR: pull functions out into separate package(s) after we understand problems better to create effective abstractions
